### PR TITLE
Revamp error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,38 +33,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad235dabf00f36301792cfe82499880ba54c6486be094d1047b02bacb67c14e8"
-dependencies = [
- "backtrace-sys",
- "cfg-if",
- "libc",
- "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca797db0057bae1a7aa2eef3283a874695455cecf08a43bfb8507ee0ebc1ed69"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "cc"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 
 [[package]]
 name = "cfg-if"
@@ -94,23 +72,23 @@ dependencies = [
 
 [[package]]
 name = "conllu"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815a564ad2473ee7a159027b9b36a81e6b1abf51f94fd576560f85ce203bd3a1"
+checksum = "ecf8598714ae5665e1aa7be0024a232b107a4a984284e251484fbdbf94aa941d"
 dependencies = [
- "failure",
  "itertools 0.8.2",
  "petgraph",
+ "thiserror",
 ]
 
 [[package]]
 name = "conllu-utils"
 version = "0.1.4"
 dependencies = [
+ "anyhow",
  "clap",
  "colored",
  "conllu",
- "failure",
  "flate2",
  "itertools 0.9.0",
  "rand",
@@ -134,28 +112,6 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-
-[[package]]
-name = "failure"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "fixedbitset"
@@ -325,12 +281,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-
-[[package]]
 name = "smallvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,24 +310,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ name = "conllu"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 clap = "2"
 colored = "1"
-conllu = "0.3.1"
-failure = "0.1"
+conllu = "0.4.1"
 flate2 = "1"
 itertools = "0.9"
 stdinout = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::io::stdout;
 
+use anyhow::Result;
 use clap::{crate_version, App, AppSettings, Arg, Shell, SubCommand};
 
 pub mod io;
@@ -16,7 +17,7 @@ static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
     AppSettings::SubcommandRequiredElseHelp,
 ];
 
-fn main() {
+fn main() -> Result<()> {
     // Known subapplications.
     let apps = vec![
         subcommands::AccuracyApp::app(),
@@ -44,7 +45,7 @@ fn main() {
 
     match matches.subcommand_name().unwrap() {
         "accuracy" => {
-            subcommands::AccuracyApp::parse(matches.subcommand_matches("accuracy").unwrap()).run()
+            subcommands::AccuracyApp::parse(matches.subcommand_matches("accuracy").unwrap())?.run()
         }
         "completions" => {
             let shell = matches
@@ -53,25 +54,29 @@ fn main() {
                 .value_of("shell")
                 .unwrap();
             write_completion_script(cli, shell.parse::<Shell>().unwrap());
+            Ok(())
         }
         "cleanup" => {
-            subcommands::CleanupApp::parse(matches.subcommand_matches("cleanup").unwrap()).run()
+            subcommands::CleanupApp::parse(matches.subcommand_matches("cleanup").unwrap())?.run()
         }
         "compare" => {
-            subcommands::CompareApp::parse(matches.subcommand_matches("compare").unwrap()).run()
+            subcommands::CompareApp::parse(matches.subcommand_matches("compare").unwrap())?.run()
         }
         "from-text" => {
-            subcommands::FromTextApp::parse(matches.subcommand_matches("from-text").unwrap()).run()
+            subcommands::FromTextApp::parse(matches.subcommand_matches("from-text").unwrap())?.run()
         }
-        "merge" => subcommands::MergeApp::parse(matches.subcommand_matches("merge").unwrap()).run(),
+        "merge" => {
+            subcommands::MergeApp::parse(matches.subcommand_matches("merge").unwrap())?.run()
+        }
         "partition" => {
-            subcommands::PartitionApp::parse(matches.subcommand_matches("partition").unwrap()).run()
+            subcommands::PartitionApp::parse(matches.subcommand_matches("partition").unwrap())?
+                .run()
         }
         "shuffle" => {
-            subcommands::ShuffleApp::parse(matches.subcommand_matches("shuffle").unwrap()).run()
+            subcommands::ShuffleApp::parse(matches.subcommand_matches("shuffle").unwrap())?.run()
         }
         "to-text" => {
-            subcommands::ToTextApp::parse(matches.subcommand_matches("to-text").unwrap()).run()
+            subcommands::ToTextApp::parse(matches.subcommand_matches("to-text").unwrap())?.run()
         }
         _unknown => unreachable!(),
     }

--- a/src/subcommands/from_text.rs
+++ b/src/subcommands/from_text.rs
@@ -1,10 +1,11 @@
 use std::io::{BufRead, BufWriter};
 
+use anyhow::{Context, Result};
 use clap::{App, ArgMatches};
 use conllu::graph::Sentence;
 use conllu::io::WriteSentence;
 use conllu::token::TokenBuilder;
-use stdinout::{Input, OrExit, Output};
+use stdinout::{Input, Output};
 
 use crate::traits::{ConlluApp, ConlluPipelineApp};
 
@@ -20,22 +21,22 @@ impl ConlluApp for FromTextApp {
         Self::pipeline_app("from-text").about("Convert tokenized text to CoNLL-U")
     }
 
-    fn parse(matches: &ArgMatches) -> Self {
+    fn parse(matches: &ArgMatches) -> Result<Self> {
         let input = Input::from(matches.value_of(Self::INPUT));
         let output = Output::from(matches.value_of(Self::OUTPUT));
 
-        FromTextApp { input, output }
+        Ok(FromTextApp { input, output })
     }
 
-    fn run(&self) {
-        let reader = self.input.buf_read().or_exit("Cannot open input", 1);
+    fn run(&self) -> Result<()> {
+        let reader = self.input.buf_read().context("Cannot open input corpus")?;
 
         let mut writer = conllu::io::Writer::new(BufWriter::new(
-            self.output.write().or_exit("Cannot open output", 1),
+            self.output.write().context("Cannot open output treebank")?,
         ));
 
         for line in reader.lines() {
-            let line = line.or_exit("Cannot read sentence", 1);
+            let line = line.context("Cannot read sentence")?;
             let trimmed = line.trim();
 
             if trimmed.is_empty() {
@@ -50,8 +51,10 @@ impl ConlluApp for FromTextApp {
             if sentence.len() != 1 {
                 writer
                     .write_sentence(&sentence)
-                    .or_exit("Cannot write sentence", 1);
+                    .context("Cannot write sentence")?;
             }
         }
+
+        Ok(())
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 
 static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
@@ -5,12 +6,15 @@ static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
     AppSettings::UnifiedHelpMessage,
 ];
 
-pub trait ConlluApp {
+pub trait ConlluApp
+where
+    Self: Sized,
+{
     fn app() -> App<'static, 'static>;
 
-    fn parse(matches: &ArgMatches) -> Self;
+    fn parse(matches: &ArgMatches) -> Result<Self>;
 
-    fn run(&self);
+    fn run(&self) -> Result<()>;
 }
 
 pub trait ConlluPipelineApp: ConlluApp {


### PR DESCRIPTION
- Use the `anyhow` crate in place of `failure`.
- Bubble up errors all the way up to `main`.
- Add context to errors.